### PR TITLE
Added functionability to use CC_SendMessage using %l and the message to be displayed in the correct language for each player

### DIFF
--- a/cromchat.inc
+++ b/cromchat.inc
@@ -229,8 +229,35 @@ stock CC_SendMessage(id, const input[], any:...)
 		}
 	}
 	
-	static szMessage[CC_MAX_MESSAGE_SIZE], bool:bNoPrefix, i
-	vformat(szMessage[1], charsmax(szMessage), input, 3)
+	static szMessage[CC_MAX_MESSAGE_SIZE]
+	
+	
+	if(id)
+	{
+		vformat(szMessage[1], charsmax(szMessage), input, 3)
+		_CC_FormatMessage(szMessage)
+		_CC_WriteMessage(id, szMessage)
+	}
+	else
+	{
+		for(new i = 0; i < iPnum; i++)
+		{
+			SetGlobalTransTarget(iPlayers[i]);
+			vformat(szMessage[1], charsmax(szMessage), input, 3)
+			_CC_FormatMessage(szMessage)
+			_CC_WriteMessage(iPlayers[i], szMessage)
+		}
+	}
+
+	CC_COLOR_FORCE = false
+	CC_COLOR_PLAYER_INDEX = 0
+
+	return strlen(szMessage)
+}
+
+stock _CC_FormatMessage(szMessage[CC_MAX_MESSAGE_SIZE]) 
+{
+	static bool:bNoPrefix, i
 	szMessage[0] = 0x01
 	
 	bNoPrefix = bool:(equal(szMessage[1], CC_NO_PREFIX, charsmax(CC_NO_PREFIX)) || equal(szMessage[2], CC_NO_PREFIX, charsmax(CC_NO_PREFIX)))
@@ -287,23 +314,6 @@ stock CC_SendMessage(id, const input[], any:...)
 			break
 		}
 	}
-	
-	if(id)
-	{
-		_CC_WriteMessage(id, szMessage)
-	}
-	else
-	{
-		for(i = 0; i < iPnum; i++)
-		{
-			_CC_WriteMessage(iPlayers[i], szMessage)
-		}
-	}
-
-	CC_COLOR_FORCE = false
-	CC_COLOR_PLAYER_INDEX = 0
-
-	return strlen(szMessage)
 }
 
 /**


### PR DESCRIPTION
Previously when using `CC_SendMessage` to send a message to all players using "%l", the message would be sent using the server's language not the player's.
Added `SetGlobalTransTarget(playerIndex)` before using `vformat` so it uses the correct language.
I had to modify the `CC_SendMessage` function a bit, mainly moved the formatting part of the message for the colors and prefixes to another function to avoid repeating the same code because I had to do the message formatting right before sending the message.